### PR TITLE
chore: respond to HEAD for monitoring

### DIFF
--- a/lib/Routes.rakumod
+++ b/lib/Routes.rakumod
@@ -20,6 +20,9 @@ sub routes() is export {
     template-location 'templates';
 
     route {
+        # respond to HEAD requests for monitoring
+        http 'HEAD', -> {
+        }
         get -> {
             template 'index.crotmp';
         }


### PR DESCRIPTION
The uptimerobot.com monitor sends HEAD requests to check if the website is up. Any other request type requires a paid upgrade.